### PR TITLE
New feature : filter issues with a minimum severity

### DIFF
--- a/org.sonar.ide.eclipse.common/src/org/sonar/ide/eclipse/common/issues/IssueSeverity.java
+++ b/org.sonar.ide.eclipse.common/src/org/sonar/ide/eclipse/common/issues/IssueSeverity.java
@@ -1,0 +1,21 @@
+package org.sonar.ide.eclipse.common.issues;
+
+import java.util.EnumSet;
+
+public enum IssueSeverity {
+	INFO, MINOR, MAJOR, CRITICAL, BLOCKER;
+
+	public EnumSet<IssueSeverity> getEqualOrGreaterSeverities() {
+		return EnumSet.range(this, BLOCKER);
+	}
+
+	public String[] getEqualOrGreaterSeveritiesAsStringArray() {
+		EnumSet<IssueSeverity> severities = getEqualOrGreaterSeverities();
+		String[] result = new String[severities.size()];
+		int i = 0;
+		for (IssueSeverity severity : severities) {
+			result[i++] = severity.name();
+		}
+		return result;
+	}
+}

--- a/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/remote/IssuesUtils.java
+++ b/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/remote/IssuesUtils.java
@@ -20,6 +20,7 @@
 package org.sonar.ide.eclipse.core.internal.remote;
 
 import org.sonar.ide.eclipse.common.issues.ISonarIssue;
+import org.sonar.ide.eclipse.common.issues.IssueSeverity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +29,7 @@ import java.util.List;
  * @author Evgeny Mandrikov
  */
 public final class IssuesUtils {
+	private static IssueSeverity minSeverityIssuesFilter = IssueSeverity.INFO;
 
   public static List<ISonarIssue> convertLines(List<ISonarIssue> issues, SourceCodeDiff diff) {
     List<ISonarIssue> result = new ArrayList<ISonarIssue>();
@@ -105,9 +107,18 @@ public final class IssuesUtils {
 
   }
 
+  public static IssueSeverity getMinSeverityIssuesFilter() {
+	  return minSeverityIssuesFilter;
+  }
+  
+  public static void setMinSeverityIssuesFilter(IssueSeverity filterIssues) {
+	  IssuesUtils.minSeverityIssuesFilter = filterIssues;
+  }
+
   /**
    * Hide utility-class constructor.
    */
   private IssuesUtils() {
   }
+
 }

--- a/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/remote/RemoteSourceCode.java
+++ b/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/remote/RemoteSourceCode.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.sonar.ide.eclipse.common.issues.ISonarIssue;
+import org.sonar.ide.eclipse.common.issues.IssueSeverity;
 
 import java.util.Date;
 import java.util.HashSet;
@@ -113,13 +114,13 @@ class RemoteSourceCode implements SourceCode {
     return diff;
   }
 
-  public List<ISonarIssue> getRemoteIssuesWithLineCorrection(IProgressMonitor monitor) {
-    final List<ISonarIssue> issues = getRemoteSonarIndex().getSonarClient().getRemoteIssuesRecursively(getKey(), monitor);
+  public List<ISonarIssue> getRemoteIssuesWithLineCorrection(IProgressMonitor monitor, IssueSeverity minSeverity) {
+    final List<ISonarIssue> issues = getRemoteSonarIndex().getSonarClient().getRemoteIssuesRecursively(getKey(), monitor, minSeverity);
     return IssuesUtils.convertLines(issues, getDiff());
   }
 
-  public List<ISonarIssue> getRemoteIssuesRecursively(IProgressMonitor monitor) {
-    return getRemoteSonarIndex().getSonarClient().getRemoteIssuesRecursively(getKey(), monitor);
+  public List<ISonarIssue> getRemoteIssuesRecursively(IProgressMonitor monitor, IssueSeverity minSeverity) {
+    return getRemoteSonarIndex().getSonarClient().getRemoteIssuesRecursively(getKey(), monitor, minSeverity);
   }
 
   /**

--- a/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/remote/SourceCode.java
+++ b/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/remote/SourceCode.java
@@ -21,6 +21,7 @@ package org.sonar.ide.eclipse.core.internal.remote;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.sonar.ide.eclipse.common.issues.ISonarIssue;
+import org.sonar.ide.eclipse.common.issues.IssueSeverity;
 
 import java.util.Date;
 import java.util.List;
@@ -51,8 +52,8 @@ public interface SourceCode extends Comparable<SourceCode> {
 
   Date getAnalysisDate();
 
-  List<ISonarIssue> getRemoteIssuesWithLineCorrection(IProgressMonitor monitor);
+  List<ISonarIssue> getRemoteIssuesWithLineCorrection(IProgressMonitor monitor, IssueSeverity minSeverity);
 
-  List<ISonarIssue> getRemoteIssuesRecursively(IProgressMonitor monitor);
+  List<ISonarIssue> getRemoteIssuesRecursively(IProgressMonitor monitor, IssueSeverity minSeverity);
 
 }

--- a/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/Messages.java
+++ b/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/Messages.java
@@ -65,6 +65,7 @@ public final class Messages extends NLS {
 
   public static String SonarPreferencePage_title;
   public static String SonarPreferencePage_description;
+  public static String SonarPreferencePage_label_filter_issues_min_severity;
   public static String SonarPreferencePage_label_marker_severity;
   public static String SonarPreferencePage_label_new_issues_marker_severity;
   public static String SonarPreferencePage_label_extra_args;

--- a/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/SonarUiPlugin.java
+++ b/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/SonarUiPlugin.java
@@ -31,9 +31,11 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonar.ide.eclipse.common.issues.IssueSeverity;
 import org.sonar.ide.eclipse.core.internal.SonarCorePlugin;
 import org.sonar.ide.eclipse.core.internal.jobs.SonarRunnerLogListener;
 import org.sonar.ide.eclipse.core.internal.markers.MarkerUtils;
+import org.sonar.ide.eclipse.core.internal.remote.IssuesUtils;
 import org.sonar.ide.eclipse.core.internal.resources.SonarProject;
 import org.sonar.ide.eclipse.core.internal.resources.SonarProperty;
 import org.sonar.ide.eclipse.ui.internal.console.SonarConsole;
@@ -47,6 +49,7 @@ public class SonarUiPlugin extends AbstractUIPlugin {
   // The shared instance
   private static SonarUiPlugin plugin;
 
+  public static final String PREF_FILTER_ISSUES_MIN_SEVERITY = "filterIssuesMinSeverity"; //$NON-NLS-1$
   public static final String PREF_MARKER_SEVERITY = "markerSeverity"; //$NON-NLS-1$
   public static final String PREF_NEW_ISSUE_MARKER_SEVERITY = "newViolationMarkerSeverity"; //$NON-NLS-1$
   public static final String PREF_EXTRA_ARGS = "extraArgs"; //$NON-NLS-1$
@@ -72,6 +75,12 @@ public class SonarUiPlugin extends AbstractUIPlugin {
 
     listener = new IPropertyChangeListener() {
       public void propertyChange(PropertyChangeEvent event) {
+		if (event.getProperty().equals(PREF_FILTER_ISSUES_MIN_SEVERITY)) {
+			IssuesUtils.setMinSeverityIssuesFilter(IssueSeverity
+					.valueOf(getPreferenceStore().getString(
+							PREF_FILTER_ISSUES_MIN_SEVERITY)));
+		}
+    	  
         if (event.getProperty().equals(PREF_MARKER_SEVERITY) || event.getProperty().equals(PREF_NEW_ISSUE_MARKER_SEVERITY)) {
           int newSeverity = getPreferenceStore().getInt(PREF_MARKER_SEVERITY);
           MarkerUtils.setMarkerSeverity(newSeverity);
@@ -123,12 +132,14 @@ public class SonarUiPlugin extends AbstractUIPlugin {
    */
   @Override
   protected void initializeDefaultPreferences(IPreferenceStore store) {
+	store.setDefault(PREF_FILTER_ISSUES_MIN_SEVERITY, IssueSeverity.INFO.name());
     store.setDefault(PREF_MARKER_SEVERITY, IMarker.SEVERITY_WARNING);
     store.setDefault(PREF_NEW_ISSUE_MARKER_SEVERITY, IMarker.SEVERITY_ERROR);
     store.setDefault(PREF_EXTRA_ARGS, "");
     store.setDefault(PREF_JVM_ARGS, "");
     MarkerUtils.setMarkerSeverity(store.getInt(PREF_MARKER_SEVERITY));
     MarkerUtils.setMarkerSeverityForNewIssues(store.getInt(PREF_NEW_ISSUE_MARKER_SEVERITY));
+    IssuesUtils.setMinSeverityIssuesFilter(IssueSeverity.valueOf(store.getString(PREF_FILTER_ISSUES_MIN_SEVERITY)));
   }
 
   public static List<SonarProperty> getExtraPropertiesForLocalAnalysis(IProject project) {

--- a/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/jobs/SynchronizeAllIssuesJob.java
+++ b/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/jobs/SynchronizeAllIssuesJob.java
@@ -20,6 +20,7 @@
 package org.sonar.ide.eclipse.ui.internal.jobs;
 
 import com.google.common.collect.ArrayListMultimap;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -32,6 +33,7 @@ import org.sonar.ide.eclipse.core.internal.SonarNature;
 import org.sonar.ide.eclipse.core.internal.markers.MarkerUtils;
 import org.sonar.ide.eclipse.core.internal.markers.SonarMarker;
 import org.sonar.ide.eclipse.core.internal.remote.EclipseSonar;
+import org.sonar.ide.eclipse.core.internal.remote.IssuesUtils;
 import org.sonar.ide.eclipse.core.internal.remote.SourceCode;
 import org.sonar.ide.eclipse.core.internal.resources.ResourceUtils;
 import org.sonar.ide.eclipse.core.internal.resources.SonarProject;
@@ -84,7 +86,7 @@ public class SynchronizeAllIssuesJob extends SynchronizeIssuesJob {
   }
 
   private void doRefreshIssues(SonarProject sonarProject, SourceCode sourceCode, IProgressMonitor monitor) throws CoreException {
-    List<ISonarIssue> issues = sourceCode.getRemoteIssuesRecursively(monitor);
+    List<ISonarIssue> issues = sourceCode.getRemoteIssuesRecursively(monitor, IssuesUtils.getMinSeverityIssuesFilter());
     // Split issues by resource
     ArrayListMultimap<String, ISonarIssue> mm = ArrayListMultimap.create();
     for (ISonarIssue issue : issues) {

--- a/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/jobs/SynchronizeIssuesJob.java
+++ b/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/jobs/SynchronizeIssuesJob.java
@@ -41,6 +41,7 @@ import org.sonar.ide.eclipse.common.issues.ISonarIssue;
 import org.sonar.ide.eclipse.core.internal.markers.MarkerUtils;
 import org.sonar.ide.eclipse.core.internal.markers.SonarMarker;
 import org.sonar.ide.eclipse.core.internal.remote.EclipseSonar;
+import org.sonar.ide.eclipse.core.internal.remote.IssuesUtils;
 import org.sonar.ide.eclipse.core.internal.remote.SourceCode;
 import org.sonar.ide.eclipse.core.internal.resources.ResourceUtils;
 import org.sonar.ide.eclipse.core.internal.resources.SonarProject;
@@ -143,7 +144,7 @@ public class SynchronizeIssuesJob extends AbstractRemoteSonarJob implements IRes
     if (sourceCode == null) {
       return Collections.emptyList();
     }
-    return sourceCode.getRemoteIssuesWithLineCorrection(monitor);
+    return sourceCode.getRemoteIssuesWithLineCorrection(monitor, IssuesUtils.getMinSeverityIssuesFilter());
   }
 
   public static void setupIssuesUpdater() {

--- a/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/messages.properties
+++ b/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/messages.properties
@@ -50,6 +50,7 @@ SonarServerPreferencePage_action_delete_tooltip=Remove Sonar server connection
 
 SonarPreferencePage_title=General Sonar Settings
 SonarPreferencePage_description=General Sonar Settings
+SonarPreferencePage_label_filter_issues_min_severity=Filter issues of severity >=
 SonarPreferencePage_label_marker_severity=Severity of Sonar markers\:
 SonarPreferencePage_label_new_issues_marker_severity=Severity of Sonar markers for new issues\:
 SonarPreferencePage_label_extra_args=Additional arguments for local analysis\:

--- a/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/preferences/SonarPreferencePage.java
+++ b/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/preferences/SonarPreferencePage.java
@@ -25,6 +25,7 @@ import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.sonar.ide.eclipse.common.issues.IssueSeverity;
 import org.sonar.ide.eclipse.ui.internal.Messages;
 import org.sonar.ide.eclipse.ui.internal.SonarUiPlugin;
 
@@ -45,6 +46,17 @@ public class SonarPreferencePage extends FieldEditorPreferencePage implements IW
   @Override
   protected void createFieldEditors() {
 
+	addField(new ComboFieldEditor(SonarUiPlugin.PREF_FILTER_ISSUES_MIN_SEVERITY,
+	            Messages.SonarPreferencePage_label_filter_issues_min_severity,
+	            new String[][] {
+	              //{"", ""},
+	              {"Info", IssueSeverity.INFO.name()},
+	              {"Minor", IssueSeverity.MINOR.name()},
+	              {"Major", IssueSeverity.MAJOR.name()},
+	              {"Critical", IssueSeverity.CRITICAL.name()},
+	              {"Blocker", IssueSeverity.BLOCKER.name()},
+	              },
+	            getFieldEditorParent()));
     addField(new ComboFieldEditor(SonarUiPlugin.PREF_MARKER_SEVERITY,
         Messages.SonarPreferencePage_label_marker_severity,
         new String[][] {

--- a/org.sonar.ide.eclipse.wsclient/src/org/sonar/ide/eclipse/wsclient/ISonarWSClientFacade.java
+++ b/org.sonar.ide.eclipse.wsclient/src/org/sonar/ide/eclipse/wsclient/ISonarWSClientFacade.java
@@ -21,6 +21,7 @@ package org.sonar.ide.eclipse.wsclient;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.sonar.ide.eclipse.common.issues.ISonarIssue;
+import org.sonar.ide.eclipse.common.issues.IssueSeverity;
 
 import java.util.Date;
 import java.util.List;
@@ -45,9 +46,9 @@ public interface ISonarWSClientFacade {
 
   String[] getRemoteCode(String resourceKey);
 
-  List<ISonarIssue> getRemoteIssuesRecursively(String resourceKey, IProgressMonitor monitor);
+  List<ISonarIssue> getRemoteIssuesRecursively(String resourceKey, IProgressMonitor monitor, IssueSeverity minSeverity);
 
-  List<ISonarIssue> getRemoteIssues(String resourceKey, IProgressMonitor monitor);
+  List<ISonarIssue> getRemoteIssues(String resourceKey, IProgressMonitor monitor, IssueSeverity minSeverity);
 
   String[] getChildrenKeys(String resourceKey);
 


### PR DESCRIPTION
In order to concentrate on most severe violations in eclipse, I'd like to hide less severe ones.
I added a dropdown in the preferences to allow the user to filter issues on a minimal severity, and modified the remote call to specify the severities to select.