### PR TITLE
fix: StackOverflowError when there is a circular dependency between projects

### DIFF
--- a/org.sonar.ide.eclipse.core.tests/src/test/java/org/sonar/ide/eclipse/jdt/internal/JavaProjectConfiguratorTest.java
+++ b/org.sonar.ide.eclipse.core.tests/src/test/java/org/sonar/ide/eclipse/jdt/internal/JavaProjectConfiguratorTest.java
@@ -25,15 +25,19 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaModel;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.core.ClasspathEntry;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import static junit.framework.Assert.assertTrue;
@@ -55,7 +59,58 @@ public class JavaProjectConfiguratorTest {
     when(project.hasNature(JavaCore.NATURE_ID)).thenReturn(true);
     assertThat(configurator.canConfigure(project), is(true));
   }
+  @Test
+  public void shouldConfigureProjectsWithCircularDependencies() throws CoreException, IOException {
+	// the bug appeared when at least 3 projects were involved: the first project depends on the second one which has a circular dependency towards the second one  
+    Properties sonarProperties = new Properties();
+	// mock three projects that depend on each other 
+    final String project1Name = "project1";
+    final String project2Name = "project2";
+    final String project3Name = "project3";
+    IJavaProject project1 = mock(IJavaProject.class, Mockito.RETURNS_DEEP_STUBS);
+    IJavaProject project2 = mock(IJavaProject.class, Mockito.RETURNS_DEEP_STUBS);
+    IJavaProject project3 = mock(IJavaProject.class, Mockito.RETURNS_DEEP_STUBS);
+    // these are required during the call to configureJavaProject
+    when(project1.getOption(JavaCore.COMPILER_SOURCE, true)).thenReturn("1.6");
+    when(project1.getOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, true)).thenReturn("1.6");
+    when(project1.getProject().getName()).thenReturn(project1Name);
+    when(project2.getProject().getName()).thenReturn(project2Name);
+    when(project3.getProject().getName()).thenReturn(project3Name);
 
+
+    // create three classpathEntries, one for each Project
+    IClasspathEntry entryProject1 = mock(IClasspathEntry.class, Mockito.RETURNS_DEEP_STUBS);
+    IClasspathEntry entryProject2 = mock(IClasspathEntry.class, Mockito.RETURNS_DEEP_STUBS);
+    IClasspathEntry entryProject3 = mock(IClasspathEntry.class, Mockito.RETURNS_DEEP_STUBS);
+    when(entryProject1.getEntryKind()).thenReturn(IClasspathEntry.CPE_PROJECT);
+	when(entryProject1.getPath().segment(0)).thenReturn(project1Name);
+    when(entryProject2.getEntryKind()).thenReturn(IClasspathEntry.CPE_PROJECT);
+    when(entryProject2.getPath().segment(0)).thenReturn(project2Name);
+    when(entryProject3.getEntryKind()).thenReturn(IClasspathEntry.CPE_PROJECT);
+    when(entryProject3.getPath().segment(0)).thenReturn(project3Name);
+    // project1 depends on project2, which depends on project3, which depends on project2
+    IClasspathEntry[] classpath1 = new IClasspathEntry[] {entryProject2};
+    IClasspathEntry[] classpath2 = new IClasspathEntry[] {entryProject3};
+    IClasspathEntry[] classpath3 = new IClasspathEntry[] {entryProject2};
+    when(project1.getResolvedClasspath(true)).thenReturn(classpath1);
+    when(project2.getResolvedClasspath(true)).thenReturn(classpath2);
+    when(project3.getResolvedClasspath(true)).thenReturn(classpath3);
+    
+    // mock the JavaModel
+    IJavaModel javaModel = mock(IJavaModel.class);
+    when(javaModel.getJavaProject(project1Name)).thenReturn(project1);
+    when(javaModel.getJavaProject(project2Name)).thenReturn(project2);
+    when(javaModel.getJavaProject(project3Name)).thenReturn(project3);
+    
+    when(project1.getJavaModel()).thenReturn(javaModel);
+    when(project2.getJavaModel()).thenReturn(javaModel);
+    when(project3.getJavaModel()).thenReturn(javaModel);
+	
+    // this call should not fail (StackOverFlowError before patch)
+    configurator.configureJavaProject(project1, sonarProperties, true);
+
+  }
+  
   @Test
   public void shouldConfigureJavaSourceAndTarget() throws JavaModelException, IOException {
     IJavaProject project = mock(IJavaProject.class);

--- a/org.sonar.ide.eclipse.jdt/src/org/sonar/ide/eclipse/jdt/internal/JavaProjectConfigurator.java
+++ b/org.sonar.ide.eclipse.jdt/src/org/sonar/ide/eclipse/jdt/internal/JavaProjectConfigurator.java
@@ -113,8 +113,8 @@ public class JavaProjectConfigurator extends ProjectConfigurator {
           IJavaProject referredProject = javaModel.getJavaProject(entry.getPath().segment(0));
           if (!context.dependentProjects().contains(referredProject)) {
             LOG.debug("Adding project: {}", referredProject.getProject().getName());
-            addClassPathToSonarProject(referredProject, context, false);
             context.dependentProjects().add(referredProject);
+            addClassPathToSonarProject(referredProject, context, false);
           }
           break;
         default:


### PR DESCRIPTION
The bug appeared when at least 3 projects were involved: the first project depends on the second one which has a circular dependency towards the second one.
This prevented me from using the plugin on our biggest project (54 subprojects), whereas the Gradle sonar-runner plugin works flawlessly.

Attached code solves the bug and adds a test that reproduces the problem.
As far as my tests go, this doesn't seem to break anything.

