### PR TITLE
Use slf4j osgi bundle for logging

### DIFF
--- a/org.sonar.ide.eclipse.core/META-INF/MANIFEST.MF
+++ b/org.sonar.ide.eclipse.core/META-INF/MANIFEST.MF
@@ -31,7 +31,7 @@ Require-Bundle: org.eclipse.equinox.security,
  org.sonar.ide.eclipse.wsclient;visibility:=reexport,
  com.google.guava;bundle-version="10.0.1",
  com.googlecode.json-simple;bundle-version="1.1.1",
- slf4j.api;bundle-version="1.6.6";visibility:=reexport,
+ org.slf4j.api;bundle-version="1.6.2";visibility:=reexport,
  org.sonar.ide.eclipse.slf4j.pde;visibility:=reexport,
  org.codehaus.sonar.runner.sonar-runner-api;bundle-version="2.3.0",
  org.sonar.ide.eclipse.common

--- a/org.sonar.ide.eclipse.thirdparty.feature/feature.xml
+++ b/org.sonar.ide.eclipse.thirdparty.feature/feature.xml
@@ -57,7 +57,7 @@
          unpack="false"/>
 
    <plugin
-         id="slf4j.api"
+         id="org.slf4j.api"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/org.sonar.ide.eclipse.wsclient/META-INF/MANIFEST.MF
+++ b/org.sonar.ide.eclipse.wsclient/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.codehaus.sonar.ws-client;bundle-version="4.2.0",
  org.apache.httpcomponents.httpclient;bundle-version="4.2.2",
  org.apache.httpcomponents.httpcore;bundle-version="4.2.2",
- slf4j.api;bundle-version="1.6.6",
+ org.slf4j.api;bundle-version="1.6.2",
  org.apache.commons.lang;bundle-version="2.6.0",
  org.sonar.ide.eclipse.slf4j.pde,
  org.sonar.ide.eclipse.common

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <license.year>2010-2014</license.year>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tycho.version>0.20.0</tycho.version>
-    <target.platform>e42</target.platform>
+    <target.platform>e44</target.platform>
 
     <!-- disable accidental deployment -->
     <sonar-ide.site>dav:http://localhost</sonar-ide.site>


### PR DESCRIPTION
To avoid breaking m2e with the following error [
java.lang.IncompatibleClassChangeError: Class
ch.qos.logback.classic.LoggerContext does not implement the requested
interface org.slf4j.ILoggerFactory] ,
this commit ensure that we used the slf4j ogsi bundle for logging.

see http://jira.codehaus.org/browse/SONARIDE-434 