### PR TITLE
Allow user to override properties

### DIFF
--- a/org.sonar.ide.eclipse.core.tests/src/test/java/org/sonar/ide/eclipse/core/internal/jobs/AnalyseProjectJobTest.java
+++ b/org.sonar.ide.eclipse.core.tests/src/test/java/org/sonar/ide/eclipse/core/internal/jobs/AnalyseProjectJobTest.java
@@ -140,13 +140,13 @@ public class AnalyseProjectJobTest extends SonarTestCase {
   }
 
   @Test
-  public void languageConfiguratorShouldOverrideExtraProps() throws Exception {
+  public void extraPropsShouldOverrideLanguageConfigurator() throws Exception {
     ((ServersManager) serversManager).getServerVersionCache().put("http://localhost:9000", "4.1");
     AnalyseProjectJob job = job(project);
     Properties props = new Properties();
     job.configureAnalysis(MONITOR, props, Arrays.asList(new SonarProperty("sonar.language", "fake")));
 
-    assertThat(props.get("sonar.language").toString()).isEqualTo("java");
+    assertThat(props.get("sonar.language").toString()).isEqualTo("fake");
   }
 
   @Test

--- a/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/jobs/AnalyseProjectJob.java
+++ b/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/jobs/AnalyseProjectJob.java
@@ -279,10 +279,6 @@ public class AnalyseProjectJob extends Job {
     IPath projectSpecificWorkDir = project.getWorkingLocation(SonarCorePlugin.PLUGIN_ID);
     File outputFile = new File(projectSpecificWorkDir.toFile(), "sonar-report.json");
 
-    // First start by appending workspace and project properties
-    for (SonarProperty sonarProperty : extraProps) {
-      properties.put(sonarProperty.getName(), sonarProperty.getValue());
-    }
 
     // Configuration by configurators (common and language specific)
     ConfiguratorUtils.configure(project, properties, getServerVersion(), monitor);
@@ -308,6 +304,11 @@ public class AnalyseProjectJob extends Job {
     properties.setProperty(SonarProperties.REPORT_OUTPUT_PROPERTY, outputFile.getName());
     if (debugEnabled) {
       properties.setProperty(SonarProperties.VERBOSE_PROPERTY, "true");
+    }
+
+    // Let user override properties by adding extra properties at the end
+    for (SonarProperty sonarProperty : extraProps) {
+      properties.put(sonarProperty.getName(), sonarProperty.getValue());
     }
     return outputFile;
   }


### PR DESCRIPTION
Allow users to override properties by adding extra properties at the end of analysis configuration.

I think this creates a better user experience because properties explicitly set by the user will be used instead of being silently ignored.

Furthermore:
* After a quick review I think this pull request addresses the same issue as mentioned in pull request #9 but is a bit smaller. 
* It will also enable users of the community c++ plugin to use the sonar-eclipse integration and will therefore solve the stackoverflow question: ["sonarqube analysis failed in eclipse throws error on local analysis due to the exception language “cpp” is not found"](http://stackoverflow.com/questions/21017860)