### PR TITLE
SONARIDE-405 Added a new sonar configuration property 'sonar.tests.regexp'.

### DIFF
--- a/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/configurator/SonarConfiguratorProperties.java
+++ b/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/configurator/SonarConfiguratorProperties.java
@@ -32,5 +32,6 @@ public interface SonarConfiguratorProperties {
   String TEST_DIRS_PROPERTY = "sonar.tests";
   String BINARIES_PROPERTY = "sonar.binaries";
   String LIBRARIES_PROPERTY = "sonar.libraries";
+  String TEST_DIRS_REGEXP_PROPERTY = "sonar.tests.regexp";
 
 }

--- a/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/resources/SonarProjectManager.java
+++ b/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/resources/SonarProjectManager.java
@@ -111,7 +111,9 @@ public class SonarProjectManager {
         String[] props = StringUtils.split(extraArgsAsString, "\r\n");
         for (String keyValuePair : props) {
           String[] keyValue = StringUtils.split(keyValuePair, "=");
-          sonarProperties.add(new SonarProperty(keyValue[0], keyValue[1]));
+          if (keyValue.length == 2) {
+            sonarProperties.add(new SonarProperty(keyValue[0], keyValue[1]));
+          }
         }
       } catch (Exception e) {
         LOG.error("Error while loading SonarQube properties", e);

--- a/org.sonar.ide.eclipse.jdt/src/org/sonar/ide/eclipse/jdt/internal/JavaProjectConfigurator.java
+++ b/org.sonar.ide.eclipse.jdt/src/org/sonar/ide/eclipse/jdt/internal/JavaProjectConfigurator.java
@@ -41,9 +41,11 @@ import java.util.Properties;
 public class JavaProjectConfigurator extends ProjectConfigurator {
 
   private static final Logger LOG = LoggerFactory.getLogger(JavaProjectConfigurator.class);
-  // TODO Allow to configure this pattern in Sonar Eclipse preferences
-  private static final String TEST_PATTERN = ".*test.*";
 
+  private static final String DEFAULT_TEST_PATTERN = ".*test.*";
+  
+  private String test_pattern;
+  
   @Override
   public boolean canConfigure(IProject project) {
     return SonarJdtPlugin.hasJavaNature(project);
@@ -69,6 +71,8 @@ public class JavaProjectConfigurator extends ProjectConfigurator {
     LOG.info("Source Java version: {}", javaSource);
     sonarProjectProperties.setProperty("sonar.java.target", javaTarget);
     LOG.info("Target Java version: {}", javaTarget);
+    
+    test_pattern = sonarProjectProperties.getProperty(SonarConfiguratorProperties.TEST_DIRS_REGEXP_PROPERTY, DEFAULT_TEST_PATTERN); 
 
     try {
       JavaProjectConfiguration configuration = new JavaProjectConfiguration();
@@ -148,7 +152,7 @@ public class JavaProjectConfigurator extends ProjectConfigurator {
       return;
     }
     String relativeDir = getRelativePath(javaProject, entry.getPath());
-    if (relativeDir.toLowerCase().matches(TEST_PATTERN)) {
+    if (relativeDir.toLowerCase().matches(test_pattern)) {
       if (topProject) {
         LOG.debug("Test directory: {}", srcDir);
         context.testDirs().add(srcDir);


### PR DESCRIPTION
The new property allows the test sources regular expression to be overridden. If the property is not set
the default regular expression '.*test.*' is used.