### PR TITLE
SonarQube server association: Project configuration setup improvement

### DIFF
--- a/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/wizards/associate/ConfigureProjectsPage.java
+++ b/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/wizards/associate/ConfigureProjectsPage.java
@@ -19,13 +19,13 @@
  */
 package org.sonar.ide.eclipse.ui.internal.wizards.associate;
 
-import com.google.common.collect.Lists;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.core.databinding.beans.BeanProperties;
 import org.eclipse.core.databinding.observable.list.WritableList;
@@ -37,6 +37,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.bindings.keys.IKeyLookup;
 import org.eclipse.jface.bindings.keys.KeyLookupFactory;
 import org.eclipse.jface.databinding.viewers.ViewerSupport;
+import org.eclipse.jface.dialogs.DialogPage;
 import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.viewers.CellEditor;
@@ -70,6 +71,9 @@ import org.sonar.ide.eclipse.wsclient.ConnectionException;
 import org.sonar.ide.eclipse.wsclient.ISonarRemoteModule;
 import org.sonar.ide.eclipse.wsclient.WSClientFactory;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+
 public class ConfigureProjectsPage extends WizardPage {
 
   private final List<IProject> projects;
@@ -77,20 +81,20 @@ public class ConfigureProjectsPage extends WizardPage {
   private final Collection<ISonarServer> sonarServers;
   private boolean alreadyRun = false;
 
-  public ConfigureProjectsPage(List<IProject> projects) {
-    super("configureProjects", "Associate with SonarQube", SonarImages.SONARWIZBAN_IMG);
-    setDescription("Select projects to add SonarQube capability.");
+  public ConfigureProjectsPage(final List<IProject> projects) {
+    super("configureProjects", Messages.ConfigureProjectsPage_title, SonarImages.SONARWIZBAN_IMG); //$NON-NLS-1$
+    setDescription(Messages.ConfigureProjectsPage_description);
     this.projects = projects;
     sonarServers = SonarCorePlugin.getServersManager().getServers();
   }
 
   @Override
-  public void createControl(Composite parent) {
-    PlatformUI.getWorkbench().getHelpSystem().setHelp(parent, SonarUiPlugin.PLUGIN_ID + ".help_associate");
+  public void createControl(final Composite parent) {
+    PlatformUI.getWorkbench().getHelpSystem().setHelp(parent, SonarUiPlugin.PLUGIN_ID + ".help_associate"); //$NON-NLS-1$
 
-    Composite container = new Composite(parent, SWT.NONE);
+    final Composite container = new Composite(parent, SWT.NONE);
 
-    GridLayout layout = new GridLayout();
+    final GridLayout layout = new GridLayout();
     layout.numColumns = 2;
     layout.marginHeight = 0;
     layout.marginWidth = 5;
@@ -102,30 +106,30 @@ public class ConfigureProjectsPage extends WizardPage {
 
     viewer.getTable().setHeaderVisible(true);
 
-    TableViewerColumn columnProject = new TableViewerColumn(viewer, SWT.LEFT);
-    columnProject.getColumn().setText("Project");
+    final TableViewerColumn columnProject = new TableViewerColumn(viewer, SWT.LEFT);
+    columnProject.getColumn().setText(Messages.ConfigureProjectsPage_project);
     columnProject.getColumn().setWidth(200);
 
-    TableViewerColumn columnSonarProject = new TableViewerColumn(viewer, SWT.LEFT);
-    columnSonarProject.getColumn().setText("SonarQube Project");
+    final TableViewerColumn columnSonarProject = new TableViewerColumn(viewer, SWT.LEFT);
+    columnSonarProject.getColumn().setText(Messages.ConfigureProjectsPage_sonarqube_project);
     columnSonarProject.getColumn().setWidth(600);
 
     columnSonarProject.setEditingSupport(new ProjectAssociationModelEditingSupport(viewer));
 
-    List<ProjectAssociationModel> list = Lists.newArrayList();
-    for (IProject project : projects) {
-      ProjectAssociationModel sonarProject = new ProjectAssociationModel(project);
+    final List<ProjectAssociationModel> list = Lists.newArrayList();
+    for (final IProject project : projects) {
+      final ProjectAssociationModel sonarProject = new ProjectAssociationModel(project);
       list.add(sonarProject);
     }
 
-    ColumnViewerEditorActivationStrategy activationSupport = createActivationSupport();
+    final ColumnViewerEditorActivationStrategy activationSupport = createActivationSupport();
 
     /*
      * Without focus highlighter, keyboard events will not be delivered to
      * ColumnViewerEditorActivationStragety#isEditorActivationEvent(...) (see above)
      */
-    FocusCellHighlighter focusCellHighlighter = new FocusCellOwnerDrawHighlighter(viewer);
-    TableViewerFocusCellManager focusCellManager = new TableViewerFocusCellManager(viewer, focusCellHighlighter);
+    final FocusCellHighlighter focusCellHighlighter = new FocusCellOwnerDrawHighlighter(viewer);
+    final TableViewerFocusCellManager focusCellManager = new TableViewerFocusCellManager(viewer, focusCellHighlighter);
 
     TableViewerEditor.create(viewer, focusCellManager, activationSupport, ColumnViewerEditor.TABBING_VERTICAL
       | ColumnViewerEditor.KEYBOARD_ACTIVATION);
@@ -142,9 +146,9 @@ public class ConfigureProjectsPage extends WizardPage {
   }
 
   private ColumnViewerEditorActivationStrategy createActivationSupport() {
-    ColumnViewerEditorActivationStrategy activationSupport = new ColumnViewerEditorActivationStrategy(viewer) {
+    final ColumnViewerEditorActivationStrategy activationSupport = new ColumnViewerEditorActivationStrategy(viewer) {
       @Override
-      protected boolean isEditorActivationEvent(ColumnViewerEditorActivationEvent event) {
+      protected boolean isEditorActivationEvent(final ColumnViewerEditorActivationEvent event) {
         return event.eventType == ColumnViewerEditorActivationEvent.TRAVERSAL
           || event.eventType == ColumnViewerEditorActivationEvent.MOUSE_CLICK_SELECTION
           || event.eventType == ColumnViewerEditorActivationEvent.PROGRAMMATIC
@@ -159,24 +163,26 @@ public class ConfigureProjectsPage extends WizardPage {
   private void scheduleAutomaticAssociation() {
     getShell().addShellListener(new ShellAdapter() {
       @Override
-      public void shellActivated(ShellEvent shellevent) {
+      public void shellActivated(final ShellEvent shellevent) {
         if (!alreadyRun) {
           alreadyRun = true;
           try {
             if (sonarServers.isEmpty()) {
-              setMessage("Please configure a SonarQube server first", IMessageProvider.ERROR);
+              setMessage(Messages.ConfigureProjectsPage_no_servers, IMessageProvider.ERROR);
             } else {
-              setMessage("", IMessageProvider.NONE);
-              getWizard().getContainer().run(true, false, new AssociateProjects(sonarServers, getProjects()));
+              setMessage("", IMessageProvider.NONE); //$NON-NLS-1$
+              getWizard().getContainer().run(true, false, new AssociateProjects(ConfigureProjectsPage.this, sonarServers, getProjects()));
             }
-          } catch (InvocationTargetException ex) {
-            SonarCorePlugin.getDefault().error(ex.getMessage(), ex);
+          } catch (final InvocationTargetException ex) {
+            // Filtering logging level, otherwise too much details on the console which user may not understand.
             if (ex.getTargetException() instanceof ConnectionException) {
-              setMessage("One of your SonarQube server cannot be reached. Please check your connection settings.", IMessageProvider.ERROR);
+              SonarCorePlugin.getDefault().debug(ex.getMessage());
+              setMessage(Messages.ConfigureProjectsPage_no_live_servers, IMessageProvider.ERROR);
             } else {
+              SonarCorePlugin.getDefault().error(ex.getMessage(), ex);
               setMessage("Error: " + ex.getMessage(), IMessageProvider.ERROR);
             }
-          } catch (Exception ex) {
+          } catch (final Exception ex) {
             SonarCorePlugin.getDefault().error(ex.getMessage(), ex);
             setMessage("Error: " + ex.getMessage(), IMessageProvider.ERROR);
           }
@@ -189,27 +195,27 @@ public class ConfigureProjectsPage extends WizardPage {
 
     SonarSearchEngineProvider contentProposalProvider = new SonarSearchEngineProvider(sonarServers, ConfigureProjectsPage.this);
 
-    public ProjectAssociationModelEditingSupport(TableViewer viewer) {
+    public ProjectAssociationModelEditingSupport(final TableViewer viewer) {
       super(viewer);
     }
 
     @Override
-    protected boolean canEdit(Object element) {
+    protected boolean canEdit(final Object element) {
       return element instanceof ProjectAssociationModel;
     }
 
     @Override
-    protected CellEditor getCellEditor(Object element) {
+    protected CellEditor getCellEditor(final Object element) {
       return new TextCellEditorWithContentProposal(viewer.getTable(), contentProposalProvider, (ProjectAssociationModel) element);
     }
 
     @Override
-    protected Object getValue(Object element) {
+    protected Object getValue(final Object element) {
       return StringUtils.trimToEmpty(((ProjectAssociationModel) element).getSonarProjectName());
     }
 
     @Override
-    protected void setValue(Object element, Object value) {
+    protected void setValue(final Object element, final Object value) {
       // Don't set value as the model was already updated in the text adapter
     }
 
@@ -224,12 +230,12 @@ public class ConfigureProjectsPage extends WizardPage {
    */
   public boolean finish() {
     final ProjectAssociationModel[] projectAssociations = getProjects();
-    for (ProjectAssociationModel projectAssociation : projectAssociations) {
+    for (final ProjectAssociationModel projectAssociation : projectAssociations) {
       if (StringUtils.isNotBlank(projectAssociation.getKey())) {
         try {
           boolean changed = false;
-          IProject project = projectAssociation.getProject();
-          SonarProject sonarProject = SonarProject.getInstance(project);
+          final IProject project = projectAssociation.getProject();
+          final SonarProject sonarProject = SonarProject.getInstance(project);
           if (!projectAssociation.getUrl().equals(sonarProject.getUrl())) {
             sonarProject.setUrl(projectAssociation.getUrl());
             changed = true;
@@ -246,11 +252,11 @@ public class ConfigureProjectsPage extends WizardPage {
             changed = true;
           }
           if (changed) {
-            boolean debugEnabled = SonarConsole.isDebugEnabled();
+            final boolean debugEnabled = SonarConsole.isDebugEnabled();
             SynchronizeAllIssuesJob.createAndSchedule(project, debugEnabled,
               SonarUiPlugin.getExtraPropertiesForLocalAnalysis(project), SonarUiPlugin.getSonarJvmArgs(), SonarUiPlugin.isForceFullPreview());
           }
-        } catch (CoreException e) {
+        } catch (final CoreException e) {
           SonarCorePlugin.getDefault().error(e.getMessage(), e);
           return false;
         }
@@ -260,7 +266,7 @@ public class ConfigureProjectsPage extends WizardPage {
   }
 
   private ProjectAssociationModel[] getProjects() {
-    WritableList projectAssociations = (WritableList) viewer.getInput();
+    final WritableList projectAssociations = (WritableList) viewer.getInput();
     return (ProjectAssociationModel[]) projectAssociations.toArray(new ProjectAssociationModel[projectAssociations.size()]);
   }
 
@@ -268,25 +274,27 @@ public class ConfigureProjectsPage extends WizardPage {
 
     private final Collection<ISonarServer> sonarServers;
     private final ProjectAssociationModel[] projectAssociations;
+    private final DialogPage configureProjectsPage;
 
-    public AssociateProjects(Collection<ISonarServer> sonarServers, ProjectAssociationModel[] projects) {
+    public AssociateProjects(final DialogPage configureProjectsPage, final Collection<ISonarServer> sonarServers, final ProjectAssociationModel[] projects) {
       Assert.isNotNull(sonarServers);
       Assert.isNotNull(projects);
+      this.configureProjectsPage = configureProjectsPage;
       this.sonarServers = sonarServers;
       this.projectAssociations = projects;
     }
 
     @Override
-    public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
-      monitor.beginTask("Associating SonarQube projects", IProgressMonitor.UNKNOWN);
+    public void run(final IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
+      monitor.beginTask(Messages.ConfigureProjectsPage_taskName, IProgressMonitor.UNKNOWN);
       // Retrieve list of all remote projects
-      Map<String, List<ISonarRemoteModule>> remoteSonarProjects = fetchAllRemoteSonarModules();
+      final Map<String, List<ISonarRemoteModule>> remoteSonarProjects = fetchAllRemoteSonarModules();
 
       // Verify that all projects already associated are found on remote. If not found projects are considered as unassociated.
       validateProjectAssociations(remoteSonarProjects);
 
       // Now check for all potential matches for a all non associated projects on all Sonar servers
-      Map<ProjectAssociationModel, List<PotentialMatchForProject>> potentialMatches = findAllPotentialMatches(remoteSonarProjects);
+      final Map<ProjectAssociationModel, List<PotentialMatchForProject>> potentialMatches = findAllPotentialMatches(remoteSonarProjects);
 
       // Now for each project try to find the better match
       findBestMatchAndAssociate(potentialMatches);
@@ -294,15 +302,15 @@ public class ConfigureProjectsPage extends WizardPage {
       monitor.done();
     }
 
-    private void findBestMatchAndAssociate(Map<ProjectAssociationModel, List<PotentialMatchForProject>> potentialMatches) {
-      for (Map.Entry<ProjectAssociationModel, List<PotentialMatchForProject>> entry : potentialMatches.entrySet()) {
-        List<PotentialMatchForProject> potentialMatchesForProject = entry.getValue();
+    private void findBestMatchAndAssociate(final Map<ProjectAssociationModel, List<PotentialMatchForProject>> potentialMatches) {
+      for (final Map.Entry<ProjectAssociationModel, List<PotentialMatchForProject>> entry : potentialMatches.entrySet()) {
+        final List<PotentialMatchForProject> potentialMatchesForProject = entry.getValue();
         if (!potentialMatchesForProject.isEmpty()) {
           // Take the better choice according to Levenshtein distance
           PotentialMatchForProject best = potentialMatchesForProject.get(0);
           int currentBestDistance = StringUtils.getLevenshteinDistance(best.getResource().getKey(), entry.getKey().getEclipseName());
-          for (PotentialMatchForProject potentialMatch : potentialMatchesForProject) {
-            int distance = StringUtils.getLevenshteinDistance(potentialMatch.getResource().getKey(), entry.getKey().getEclipseName());
+          for (final PotentialMatchForProject potentialMatch : potentialMatchesForProject) {
+            final int distance = StringUtils.getLevenshteinDistance(potentialMatch.getResource().getKey(), entry.getKey().getEclipseName());
             if (distance < currentBestDistance) {
               best = potentialMatch;
               currentBestDistance = distance;
@@ -313,18 +321,18 @@ public class ConfigureProjectsPage extends WizardPage {
       }
     }
 
-    private Map<ProjectAssociationModel, List<PotentialMatchForProject>> findAllPotentialMatches(Map<String, List<ISonarRemoteModule>> remoteSonarProjects) {
-      Map<ProjectAssociationModel, List<PotentialMatchForProject>> potentialMatches = new HashMap<ProjectAssociationModel, List<PotentialMatchForProject>>();
-      for (Map.Entry<String, List<ISonarRemoteModule>> entry : remoteSonarProjects.entrySet()) {
-        String url = entry.getKey();
-        List<ISonarRemoteModule> resources = entry.getValue();
-        for (ProjectAssociationModel sonarProject : projectAssociations) {
+    private Map<ProjectAssociationModel, List<PotentialMatchForProject>> findAllPotentialMatches(final Map<String, List<ISonarRemoteModule>> remoteSonarProjects) {
+      final Map<ProjectAssociationModel, List<PotentialMatchForProject>> potentialMatches = new HashMap<ProjectAssociationModel, List<PotentialMatchForProject>>();
+      for (final Map.Entry<String, List<ISonarRemoteModule>> entry : remoteSonarProjects.entrySet()) {
+        final String url = entry.getKey();
+        final List<ISonarRemoteModule> resources = entry.getValue();
+        for (final ProjectAssociationModel sonarProject : projectAssociations) {
           if (StringUtils.isBlank(sonarProject.getKey())) {
             // Not associated yet
             if (!potentialMatches.containsKey(sonarProject)) {
               potentialMatches.put(sonarProject, new ArrayList<PotentialMatchForProject>());
             }
-            for (ISonarRemoteModule resource : resources) {
+            for (final ISonarRemoteModule resource : resources) {
               // A resource is a potential match if resource key contains Eclipse name
               if (resource.getKey().contains(sonarProject.getEclipseName())) {
                 potentialMatches.get(sonarProject).add(new PotentialMatchForProject(resource, url));
@@ -336,21 +344,21 @@ public class ConfigureProjectsPage extends WizardPage {
       return potentialMatches;
     }
 
-    private void validateProjectAssociations(Map<String, List<ISonarRemoteModule>> remoteSonarProjects) {
-      for (ProjectAssociationModel projectAssociation : projectAssociations) {
+    private void validateProjectAssociations(final Map<String, List<ISonarRemoteModule>> remoteSonarProjects) {
+      for (final ProjectAssociationModel projectAssociation : projectAssociations) {
         if (SonarNature.hasSonarNature(projectAssociation.getProject())) {
-          SonarProject sonarProject = SonarProject.getInstance(projectAssociation.getProject());
-          String key = sonarProject.getKey();
-          String url = sonarProject.getUrl();
+          final SonarProject sonarProject = SonarProject.getInstance(projectAssociation.getProject());
+          final String key = sonarProject.getKey();
+          final String url = sonarProject.getUrl();
           validateProjectAssociation(remoteSonarProjects, projectAssociation, key, url);
         }
       }
     }
 
-    private void validateProjectAssociation(Map<String, List<ISonarRemoteModule>> remoteSonarProjects, ProjectAssociationModel projectAssociation, String key, String url) {
+    private void validateProjectAssociation(final Map<String, List<ISonarRemoteModule>> remoteSonarProjects, final ProjectAssociationModel projectAssociation, final String key, final String url) {
       boolean found = false;
       if (remoteSonarProjects.containsKey(url)) {
-        for (ISonarRemoteModule remoteProject : remoteSonarProjects.get(url)) {
+        for (final ISonarRemoteModule remoteProject : remoteSonarProjects.get(url)) {
           if (remoteProject.getKey().equals(key)) {
             found = true;
             // Call associate to have the name
@@ -366,19 +374,52 @@ public class ConfigureProjectsPage extends WizardPage {
     }
 
     private Map<String, List<ISonarRemoteModule>> fetchAllRemoteSonarModules() {
-      Map<String, List<ISonarRemoteModule>> remoteSonarModules = new HashMap<String, List<ISonarRemoteModule>>();
-      for (ISonarServer sonarServer : sonarServers) {
-        List<ISonarRemoteModule> remoteModules = WSClientFactory.getSonarClient(sonarServer).listAllRemoteModules();
-        remoteSonarModules.put(sonarServer.getUrl(), remoteModules);
+      final Map<String, List<ISonarRemoteModule>> remoteSonarModules = new HashMap<String, List<ISonarRemoteModule>>();
+      final List<ISonarServer> nonReachableServers = new ArrayList<ISonarServer>();
+      for (final ISonarServer sonarServer : sonarServers) {
+        try {
+          final List<ISonarRemoteModule> remoteModules = WSClientFactory.getSonarClient(sonarServer).listAllRemoteModules();
+          remoteSonarModules.put(sonarServer.getUrl(), remoteModules);
+        } catch (final ConnectionException exception) {
+          nonReachableServers.add(sonarServer);
+          if (nonReachableServers.size() == sonarServers.size()) {
+            // All servers are non-reachable.
+            throw exception;
+          }
+        }
+      }
+      // Provide non-reachable servers detail
+      if (!nonReachableServers.isEmpty()) {
+        final String message = Messages.ConfigureProjectsPage_only_few_servers_live;
+        final StringBuilder builder = new StringBuilder(message);
+        builder.append("\n"); //$NON-NLS-1$
+        for (final ISonarServer nonReachableServer : nonReachableServers) {
+          builder.append("\t"); //$NON-NLS-1$
+          builder.append(nonReachableServer.getUrl());
+          final String username = nonReachableServer.getUsername();
+          if (!Strings.isNullOrEmpty(username)) {
+            builder.append(","); //$NON-NLS-1$
+            builder.append(username);
+          }
+          builder.append("\n"); //$NON-NLS-1$
+        }
+        builder.append(Messages.ConfigureProjectsPage_check_conn_settings);
+        configureProjectsPage.getShell().getDisplay().asyncExec(new Runnable() {
+
+          @Override
+          public void run() {
+            configureProjectsPage.setMessage(builder.toString(), IMessageProvider.ERROR);
+          }
+        });
       }
       return remoteSonarModules;
     }
 
     private static class PotentialMatchForProject {
-      private ISonarRemoteModule resource;
-      private String host;
+      private final ISonarRemoteModule resource;
+      private final String host;
 
-      public PotentialMatchForProject(ISonarRemoteModule resource, String host) {
+      public PotentialMatchForProject(final ISonarRemoteModule resource, final String host) {
         super();
         this.resource = resource;
         this.host = host;

--- a/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/wizards/associate/ConfigureProjectsPage.java
+++ b/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/wizards/associate/ConfigureProjectsPage.java
@@ -81,7 +81,7 @@ public class ConfigureProjectsPage extends WizardPage {
   private final Collection<ISonarServer> sonarServers;
   private boolean alreadyRun = false;
 
-  public ConfigureProjectsPage(final List<IProject> projects) {
+  public ConfigureProjectsPage(List<IProject> projects) {
     super("configureProjects", Messages.ConfigureProjectsPage_title, SonarImages.SONARWIZBAN_IMG); //$NON-NLS-1$
     setDescription(Messages.ConfigureProjectsPage_description);
     this.projects = projects;
@@ -89,12 +89,12 @@ public class ConfigureProjectsPage extends WizardPage {
   }
 
   @Override
-  public void createControl(final Composite parent) {
-    PlatformUI.getWorkbench().getHelpSystem().setHelp(parent, SonarUiPlugin.PLUGIN_ID + ".help_associate"); //$NON-NLS-1$
+  public void createControl(Composite parent) {
+    PlatformUI.getWorkbench().getHelpSystem().setHelp(parent, SonarUiPlugin.PLUGIN_ID + ".help_associate");
 
-    final Composite container = new Composite(parent, SWT.NONE);
+    Composite container = new Composite(parent, SWT.NONE);
 
-    final GridLayout layout = new GridLayout();
+    GridLayout layout = new GridLayout();
     layout.numColumns = 2;
     layout.marginHeight = 0;
     layout.marginWidth = 5;
@@ -106,30 +106,30 @@ public class ConfigureProjectsPage extends WizardPage {
 
     viewer.getTable().setHeaderVisible(true);
 
-    final TableViewerColumn columnProject = new TableViewerColumn(viewer, SWT.LEFT);
+    TableViewerColumn columnProject = new TableViewerColumn(viewer, SWT.LEFT);
     columnProject.getColumn().setText(Messages.ConfigureProjectsPage_project);
     columnProject.getColumn().setWidth(200);
 
-    final TableViewerColumn columnSonarProject = new TableViewerColumn(viewer, SWT.LEFT);
+    TableViewerColumn columnSonarProject = new TableViewerColumn(viewer, SWT.LEFT);
     columnSonarProject.getColumn().setText(Messages.ConfigureProjectsPage_sonarqube_project);
     columnSonarProject.getColumn().setWidth(600);
 
     columnSonarProject.setEditingSupport(new ProjectAssociationModelEditingSupport(viewer));
 
-    final List<ProjectAssociationModel> list = Lists.newArrayList();
-    for (final IProject project : projects) {
-      final ProjectAssociationModel sonarProject = new ProjectAssociationModel(project);
+    List<ProjectAssociationModel> list = Lists.newArrayList();
+    for (IProject project : projects) {
+      ProjectAssociationModel sonarProject = new ProjectAssociationModel(project);
       list.add(sonarProject);
     }
 
-    final ColumnViewerEditorActivationStrategy activationSupport = createActivationSupport();
+    ColumnViewerEditorActivationStrategy activationSupport = createActivationSupport();
 
     /*
      * Without focus highlighter, keyboard events will not be delivered to
      * ColumnViewerEditorActivationStragety#isEditorActivationEvent(...) (see above)
      */
-    final FocusCellHighlighter focusCellHighlighter = new FocusCellOwnerDrawHighlighter(viewer);
-    final TableViewerFocusCellManager focusCellManager = new TableViewerFocusCellManager(viewer, focusCellHighlighter);
+    FocusCellHighlighter focusCellHighlighter = new FocusCellOwnerDrawHighlighter(viewer);
+    TableViewerFocusCellManager focusCellManager = new TableViewerFocusCellManager(viewer, focusCellHighlighter);
 
     TableViewerEditor.create(viewer, focusCellManager, activationSupport, ColumnViewerEditor.TABBING_VERTICAL
       | ColumnViewerEditor.KEYBOARD_ACTIVATION);
@@ -146,9 +146,9 @@ public class ConfigureProjectsPage extends WizardPage {
   }
 
   private ColumnViewerEditorActivationStrategy createActivationSupport() {
-    final ColumnViewerEditorActivationStrategy activationSupport = new ColumnViewerEditorActivationStrategy(viewer) {
+    ColumnViewerEditorActivationStrategy activationSupport = new ColumnViewerEditorActivationStrategy(viewer) {
       @Override
-      protected boolean isEditorActivationEvent(final ColumnViewerEditorActivationEvent event) {
+      protected boolean isEditorActivationEvent(ColumnViewerEditorActivationEvent event) {
         return event.eventType == ColumnViewerEditorActivationEvent.TRAVERSAL
           || event.eventType == ColumnViewerEditorActivationEvent.MOUSE_CLICK_SELECTION
           || event.eventType == ColumnViewerEditorActivationEvent.PROGRAMMATIC
@@ -163,7 +163,7 @@ public class ConfigureProjectsPage extends WizardPage {
   private void scheduleAutomaticAssociation() {
     getShell().addShellListener(new ShellAdapter() {
       @Override
-      public void shellActivated(final ShellEvent shellevent) {
+      public void shellActivated(ShellEvent shellevent) {
         if (!alreadyRun) {
           alreadyRun = true;
           try {
@@ -173,7 +173,7 @@ public class ConfigureProjectsPage extends WizardPage {
               setMessage("", IMessageProvider.NONE); //$NON-NLS-1$
               getWizard().getContainer().run(true, false, new AssociateProjects(ConfigureProjectsPage.this, sonarServers, getProjects()));
             }
-          } catch (final InvocationTargetException ex) {
+          } catch (InvocationTargetException ex) {
             // Filtering logging level, otherwise too much details on the console which user may not understand.
             if (ex.getTargetException() instanceof ConnectionException) {
               SonarCorePlugin.getDefault().debug(ex.getMessage());
@@ -182,7 +182,7 @@ public class ConfigureProjectsPage extends WizardPage {
               SonarCorePlugin.getDefault().error(ex.getMessage(), ex);
               setMessage("Error: " + ex.getMessage(), IMessageProvider.ERROR);
             }
-          } catch (final Exception ex) {
+          } catch (Exception ex) {
             SonarCorePlugin.getDefault().error(ex.getMessage(), ex);
             setMessage("Error: " + ex.getMessage(), IMessageProvider.ERROR);
           }
@@ -195,27 +195,27 @@ public class ConfigureProjectsPage extends WizardPage {
 
     SonarSearchEngineProvider contentProposalProvider = new SonarSearchEngineProvider(sonarServers, ConfigureProjectsPage.this);
 
-    public ProjectAssociationModelEditingSupport(final TableViewer viewer) {
+    public ProjectAssociationModelEditingSupport(TableViewer viewer) {
       super(viewer);
     }
 
     @Override
-    protected boolean canEdit(final Object element) {
+    protected boolean canEdit(Object element) {
       return element instanceof ProjectAssociationModel;
     }
 
     @Override
-    protected CellEditor getCellEditor(final Object element) {
+    protected CellEditor getCellEditor(Object element) {
       return new TextCellEditorWithContentProposal(viewer.getTable(), contentProposalProvider, (ProjectAssociationModel) element);
     }
 
     @Override
-    protected Object getValue(final Object element) {
+    protected Object getValue(Object element) {
       return StringUtils.trimToEmpty(((ProjectAssociationModel) element).getSonarProjectName());
     }
 
     @Override
-    protected void setValue(final Object element, final Object value) {
+    protected void setValue(Object element, Object value) {
       // Don't set value as the model was already updated in the text adapter
     }
 
@@ -230,12 +230,12 @@ public class ConfigureProjectsPage extends WizardPage {
    */
   public boolean finish() {
     final ProjectAssociationModel[] projectAssociations = getProjects();
-    for (final ProjectAssociationModel projectAssociation : projectAssociations) {
+    for (ProjectAssociationModel projectAssociation : projectAssociations) {
       if (StringUtils.isNotBlank(projectAssociation.getKey())) {
         try {
           boolean changed = false;
-          final IProject project = projectAssociation.getProject();
-          final SonarProject sonarProject = SonarProject.getInstance(project);
+          IProject project = projectAssociation.getProject();
+          SonarProject sonarProject = SonarProject.getInstance(project);
           if (!projectAssociation.getUrl().equals(sonarProject.getUrl())) {
             sonarProject.setUrl(projectAssociation.getUrl());
             changed = true;
@@ -252,11 +252,11 @@ public class ConfigureProjectsPage extends WizardPage {
             changed = true;
           }
           if (changed) {
-            final boolean debugEnabled = SonarConsole.isDebugEnabled();
+            boolean debugEnabled = SonarConsole.isDebugEnabled();
             SynchronizeAllIssuesJob.createAndSchedule(project, debugEnabled,
               SonarUiPlugin.getExtraPropertiesForLocalAnalysis(project), SonarUiPlugin.getSonarJvmArgs(), SonarUiPlugin.isForceFullPreview());
           }
-        } catch (final CoreException e) {
+        } catch (CoreException e) {
           SonarCorePlugin.getDefault().error(e.getMessage(), e);
           return false;
         }
@@ -266,7 +266,7 @@ public class ConfigureProjectsPage extends WizardPage {
   }
 
   private ProjectAssociationModel[] getProjects() {
-    final WritableList projectAssociations = (WritableList) viewer.getInput();
+    WritableList projectAssociations = (WritableList) viewer.getInput();
     return (ProjectAssociationModel[]) projectAssociations.toArray(new ProjectAssociationModel[projectAssociations.size()]);
   }
 
@@ -276,7 +276,7 @@ public class ConfigureProjectsPage extends WizardPage {
     private final ProjectAssociationModel[] projectAssociations;
     private final DialogPage configureProjectsPage;
 
-    public AssociateProjects(final DialogPage configureProjectsPage, final Collection<ISonarServer> sonarServers, final ProjectAssociationModel[] projects) {
+    public AssociateProjects(DialogPage configureProjectsPage, Collection<ISonarServer> sonarServers, ProjectAssociationModel[] projects) {
       Assert.isNotNull(sonarServers);
       Assert.isNotNull(projects);
       this.configureProjectsPage = configureProjectsPage;
@@ -285,16 +285,16 @@ public class ConfigureProjectsPage extends WizardPage {
     }
 
     @Override
-    public void run(final IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
+    public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
       monitor.beginTask(Messages.ConfigureProjectsPage_taskName, IProgressMonitor.UNKNOWN);
       // Retrieve list of all remote projects
-      final Map<String, List<ISonarRemoteModule>> remoteSonarProjects = fetchAllRemoteSonarModules();
+      Map<String, List<ISonarRemoteModule>> remoteSonarProjects = fetchAllRemoteSonarModules();
 
       // Verify that all projects already associated are found on remote. If not found projects are considered as unassociated.
       validateProjectAssociations(remoteSonarProjects);
 
       // Now check for all potential matches for a all non associated projects on all Sonar servers
-      final Map<ProjectAssociationModel, List<PotentialMatchForProject>> potentialMatches = findAllPotentialMatches(remoteSonarProjects);
+      Map<ProjectAssociationModel, List<PotentialMatchForProject>> potentialMatches = findAllPotentialMatches(remoteSonarProjects);
 
       // Now for each project try to find the better match
       findBestMatchAndAssociate(potentialMatches);
@@ -302,15 +302,15 @@ public class ConfigureProjectsPage extends WizardPage {
       monitor.done();
     }
 
-    private void findBestMatchAndAssociate(final Map<ProjectAssociationModel, List<PotentialMatchForProject>> potentialMatches) {
-      for (final Map.Entry<ProjectAssociationModel, List<PotentialMatchForProject>> entry : potentialMatches.entrySet()) {
-        final List<PotentialMatchForProject> potentialMatchesForProject = entry.getValue();
+    private void findBestMatchAndAssociate(Map<ProjectAssociationModel, List<PotentialMatchForProject>> potentialMatches) {
+      for (Map.Entry<ProjectAssociationModel, List<PotentialMatchForProject>> entry : potentialMatches.entrySet()) {
+        List<PotentialMatchForProject> potentialMatchesForProject = entry.getValue();
         if (!potentialMatchesForProject.isEmpty()) {
           // Take the better choice according to Levenshtein distance
           PotentialMatchForProject best = potentialMatchesForProject.get(0);
           int currentBestDistance = StringUtils.getLevenshteinDistance(best.getResource().getKey(), entry.getKey().getEclipseName());
-          for (final PotentialMatchForProject potentialMatch : potentialMatchesForProject) {
-            final int distance = StringUtils.getLevenshteinDistance(potentialMatch.getResource().getKey(), entry.getKey().getEclipseName());
+          for (PotentialMatchForProject potentialMatch : potentialMatchesForProject) {
+            int distance = StringUtils.getLevenshteinDistance(potentialMatch.getResource().getKey(), entry.getKey().getEclipseName());
             if (distance < currentBestDistance) {
               best = potentialMatch;
               currentBestDistance = distance;
@@ -321,18 +321,18 @@ public class ConfigureProjectsPage extends WizardPage {
       }
     }
 
-    private Map<ProjectAssociationModel, List<PotentialMatchForProject>> findAllPotentialMatches(final Map<String, List<ISonarRemoteModule>> remoteSonarProjects) {
-      final Map<ProjectAssociationModel, List<PotentialMatchForProject>> potentialMatches = new HashMap<ProjectAssociationModel, List<PotentialMatchForProject>>();
-      for (final Map.Entry<String, List<ISonarRemoteModule>> entry : remoteSonarProjects.entrySet()) {
-        final String url = entry.getKey();
-        final List<ISonarRemoteModule> resources = entry.getValue();
-        for (final ProjectAssociationModel sonarProject : projectAssociations) {
+    private Map<ProjectAssociationModel, List<PotentialMatchForProject>> findAllPotentialMatches(Map<String, List<ISonarRemoteModule>> remoteSonarProjects) {
+      Map<ProjectAssociationModel, List<PotentialMatchForProject>> potentialMatches = new HashMap<ProjectAssociationModel, List<PotentialMatchForProject>>();
+      for (Map.Entry<String, List<ISonarRemoteModule>> entry : remoteSonarProjects.entrySet()) {
+        String url = entry.getKey();
+        List<ISonarRemoteModule> resources = entry.getValue();
+        for (ProjectAssociationModel sonarProject : projectAssociations) {
           if (StringUtils.isBlank(sonarProject.getKey())) {
             // Not associated yet
             if (!potentialMatches.containsKey(sonarProject)) {
               potentialMatches.put(sonarProject, new ArrayList<PotentialMatchForProject>());
             }
-            for (final ISonarRemoteModule resource : resources) {
+            for (ISonarRemoteModule resource : resources) {
               // A resource is a potential match if resource key contains Eclipse name
               if (resource.getKey().contains(sonarProject.getEclipseName())) {
                 potentialMatches.get(sonarProject).add(new PotentialMatchForProject(resource, url));
@@ -344,21 +344,21 @@ public class ConfigureProjectsPage extends WizardPage {
       return potentialMatches;
     }
 
-    private void validateProjectAssociations(final Map<String, List<ISonarRemoteModule>> remoteSonarProjects) {
-      for (final ProjectAssociationModel projectAssociation : projectAssociations) {
+    private void validateProjectAssociations(Map<String, List<ISonarRemoteModule>> remoteSonarProjects) {
+      for (ProjectAssociationModel projectAssociation : projectAssociations) {
         if (SonarNature.hasSonarNature(projectAssociation.getProject())) {
-          final SonarProject sonarProject = SonarProject.getInstance(projectAssociation.getProject());
-          final String key = sonarProject.getKey();
-          final String url = sonarProject.getUrl();
+          SonarProject sonarProject = SonarProject.getInstance(projectAssociation.getProject());
+          String key = sonarProject.getKey();
+          String url = sonarProject.getUrl();
           validateProjectAssociation(remoteSonarProjects, projectAssociation, key, url);
         }
       }
     }
 
-    private void validateProjectAssociation(final Map<String, List<ISonarRemoteModule>> remoteSonarProjects, final ProjectAssociationModel projectAssociation, final String key, final String url) {
+    private void validateProjectAssociation(Map<String, List<ISonarRemoteModule>> remoteSonarProjects, ProjectAssociationModel projectAssociation, String key, String url) {
       boolean found = false;
       if (remoteSonarProjects.containsKey(url)) {
-        for (final ISonarRemoteModule remoteProject : remoteSonarProjects.get(url)) {
+        for (ISonarRemoteModule remoteProject : remoteSonarProjects.get(url)) {
           if (remoteProject.getKey().equals(key)) {
             found = true;
             // Call associate to have the name
@@ -374,13 +374,13 @@ public class ConfigureProjectsPage extends WizardPage {
     }
 
     private Map<String, List<ISonarRemoteModule>> fetchAllRemoteSonarModules() {
-      final Map<String, List<ISonarRemoteModule>> remoteSonarModules = new HashMap<String, List<ISonarRemoteModule>>();
-      final List<ISonarServer> nonReachableServers = new ArrayList<ISonarServer>();
-      for (final ISonarServer sonarServer : sonarServers) {
+      Map<String, List<ISonarRemoteModule>> remoteSonarModules = new HashMap<String, List<ISonarRemoteModule>>();
+      List<ISonarServer> nonReachableServers = new ArrayList<ISonarServer>();
+      for (ISonarServer sonarServer : sonarServers) {
         try {
-          final List<ISonarRemoteModule> remoteModules = WSClientFactory.getSonarClient(sonarServer).listAllRemoteModules();
+          List<ISonarRemoteModule> remoteModules = WSClientFactory.getSonarClient(sonarServer).listAllRemoteModules();
           remoteSonarModules.put(sonarServer.getUrl(), remoteModules);
-        } catch (final ConnectionException exception) {
+        } catch (ConnectionException exception) {
           nonReachableServers.add(sonarServer);
           if (nonReachableServers.size() == sonarServers.size()) {
             // All servers are non-reachable.
@@ -416,10 +416,10 @@ public class ConfigureProjectsPage extends WizardPage {
     }
 
     private static class PotentialMatchForProject {
-      private final ISonarRemoteModule resource;
-      private final String host;
+      private ISonarRemoteModule resource;
+      private String host;
 
-      public PotentialMatchForProject(final ISonarRemoteModule resource, final String host) {
+      public PotentialMatchForProject(ISonarRemoteModule resource, String host) {
         super();
         this.resource = resource;
         this.host = host;

--- a/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/wizards/associate/Messages.java
+++ b/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/wizards/associate/Messages.java
@@ -1,15 +1,30 @@
 /*
- * Copyright © 2015 Siemens Medical Solutions USA, Inc.
- * All Rights Reserved.
+ * SonarQube Eclipse
+ * Copyright (C) 2010-2015 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
 package org.sonar.ide.eclipse.ui.internal.wizards.associate;
 
 import org.eclipse.osgi.util.NLS;
 
 /**
- * TODO Insert description sentence here.
+ * Messsages.
  *
- * @author z0035kms/Hemantkumar Chigadani
+ * @author Hemantkumar Chigadani
  */
 public class Messages extends NLS {
   private static final String BUNDLE_NAME = "org.sonar.ide.eclipse.ui.internal.wizards.associate.messages"; //$NON-NLS-1$

--- a/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/wizards/associate/Messages.java
+++ b/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/wizards/associate/Messages.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 Siemens Medical Solutions USA, Inc.
+ * All Rights Reserved.
+ */
+package org.sonar.ide.eclipse.ui.internal.wizards.associate;
+
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * TODO Insert description sentence here.
+ *
+ * @author z0035kms/Hemantkumar Chigadani
+ */
+public class Messages extends NLS {
+  private static final String BUNDLE_NAME = "org.sonar.ide.eclipse.ui.internal.wizards.associate.messages"; //$NON-NLS-1$
+  public static String ConfigureProjectsPage_check_conn_settings;
+  public static String ConfigureProjectsPage_description;
+  public static String ConfigureProjectsPage_no_live_servers;
+  public static String ConfigureProjectsPage_no_servers;
+  public static String ConfigureProjectsPage_only_few_servers_live;
+  public static String ConfigureProjectsPage_project;
+  public static String ConfigureProjectsPage_sonarqube_project;
+  public static String ConfigureProjectsPage_taskName;
+  public static String ConfigureProjectsPage_title;
+  static {
+    // initialize resource bundle
+    NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+  }
+
+  private Messages() {
+  }
+}

--- a/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/wizards/associate/messages.properties
+++ b/org.sonar.ide.eclipse.ui/src/org/sonar/ide/eclipse/ui/internal/wizards/associate/messages.properties
@@ -1,0 +1,9 @@
+ConfigureProjectsPage_check_conn_settings=Please check your connection settings.
+ConfigureProjectsPage_description=Select projects to add SonarQube capability.
+ConfigureProjectsPage_no_live_servers=All of SonarQube servers cannot be reached. Please check your connection settings.
+ConfigureProjectsPage_no_servers=Please configure a SonarQube server first
+ConfigureProjectsPage_only_few_servers_live=Few of the SonarQube servers can be reached but following could not.
+ConfigureProjectsPage_project=Project
+ConfigureProjectsPage_sonarqube_project=SonarQube Project
+ConfigureProjectsPage_taskName=Associating SonarQube projects
+ConfigureProjectsPage_title=Associate with SonarQube


### PR DESCRIPTION
SonaQube server association action and it's dialogue improvement when few of saved/persisted SonarQube servers are not reachable at given time. 

User should be allowed to associate a workspace project to a SonarQube server if at-least one of SonarQube servers is reachable, with additional warning description shown on the association dialogue about non reachable servers details.

Fix to a Issue: You can not associated a SonarQube server to a workspace project if any one of saved/persisted SonarQube servers is not reachable.