### PR TITLE
Lazy caching of Sonar servers version.

### DIFF
--- a/org.sonar.ide.eclipse.core.tests/src/test/java/org/sonar/ide/eclipse/core/internal/jobs/AnalyzeProjectJobTest.java
+++ b/org.sonar.ide.eclipse.core.tests/src/test/java/org/sonar/ide/eclipse/core/internal/jobs/AnalyzeProjectJobTest.java
@@ -19,11 +19,15 @@
  */
 package org.sonar.ide.eclipse.core.internal.jobs;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -42,24 +46,19 @@ import org.sonar.ide.eclipse.core.internal.SonarProperties;
 import org.sonar.ide.eclipse.core.internal.markers.MarkerUtils;
 import org.sonar.ide.eclipse.core.internal.resources.SonarProperty;
 import org.sonar.ide.eclipse.core.internal.servers.ISonarServersManager;
-import org.sonar.ide.eclipse.core.internal.servers.ServersManager;
 import org.sonar.ide.eclipse.tests.common.SonarTestCase;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 public class AnalyzeProjectJobTest extends SonarTestCase {
 
   public org.junit.rules.ExternalResource test = null;
   private static IProject project;
-  private static ISonarServer server;
   private static ISonarServersManager serversManager;
 
   @BeforeClass
   public static void prepare() throws Exception {
     serversManager = SonarCorePlugin.getServersManager();
-    server = serversManager.create("http://localhost:9000", null, null);
-    SonarCorePlugin.getServersManager().addServer(server);
+    final ISonarServer server = serversManager.create("http://localhost:9000", null, null);
+    SonarCorePlugin.getServersManager().addServer(new FakedVersionedSonarServer(server, "4.0"));
 
     project = importEclipseProject("reference");
 
@@ -72,26 +71,25 @@ public class AnalyzeProjectJobTest extends SonarTestCase {
     MarkerUtils.deleteIssuesMarkers(project);
   }
 
-  private static AnalyzeProjectJob job(IProject project) {
+  private static AnalyzeProjectJob job(final IProject project) {
     return new AnalyzeProjectJob(new AnalyseProjectRequest(project));
   }
 
   @Test
   public void shouldConfigureAnalysis() throws Exception {
-    ((ServersManager) serversManager).getServerVersionCache().put("http://localhost:9000", "4.0");
-    AnalyzeProjectJob job = job(project);
+    final AnalyzeProjectJob job = job(project);
     job.setIncremental(true);
-    Properties props = new Properties();
+    final Properties props = new Properties();
     job.configureAnalysis(MONITOR, props, new ArrayList<SonarProperty>());
 
     assertThat(props.get(SonarProperties.SONAR_URL).toString()).isEqualTo("http://localhost:9000");
     assertThat(props.get(SonarProperties.PROJECT_KEY_PROPERTY).toString()).isEqualTo("bar:foo");
     assertThat(props.get(SonarProperties.ANALYSIS_MODE).toString()).isEqualTo("incremental");
     // SONARIDE-386 check that at least some JARs from the VM are appended
-    List<String> libs = Arrays.asList(props.get(SonarConfiguratorProperties.LIBRARIES_PROPERTY).toString().split(","));
+    final List<String> libs = Arrays.asList(props.get(SonarConfiguratorProperties.LIBRARIES_PROPERTY).toString().split(","));
     assertThat(libs).doesNotHaveDuplicates();
     boolean foundRT = false;
-    for (String lib : libs) {
+    for (final String lib : libs) {
       if (lib.endsWith("rt.jar") || lib.endsWith("classes.jar") /* For Mac JDK 1.6 */) {
         foundRT = true;
         break;
@@ -104,10 +102,9 @@ public class AnalyzeProjectJobTest extends SonarTestCase {
 
   @Test
   public void shouldForceFullPreview() throws Exception {
-    ((ServersManager) serversManager).getServerVersionCache().put("http://localhost:9000", "4.0");
-    AnalyzeProjectJob job = job(project);
+    final AnalyzeProjectJob job = job(project);
     job.setIncremental(false);
-    Properties props = new Properties();
+    final Properties props = new Properties();
     job.configureAnalysis(MONITOR, props, new ArrayList<SonarProperty>());
 
     assertThat(props.get(SonarProperties.SONAR_URL).toString()).isEqualTo("http://localhost:9000");
@@ -117,9 +114,8 @@ public class AnalyzeProjectJobTest extends SonarTestCase {
 
   @Test
   public void shouldConfigureAnalysisWithExtraProps() throws Exception {
-    ((ServersManager) serversManager).getServerVersionCache().put("http://localhost:9000", "4.0");
-    AnalyzeProjectJob job = job(project);
-    Properties props = new Properties();
+    final AnalyzeProjectJob job = job(project);
+    final Properties props = new Properties();
     job.configureAnalysis(MONITOR, props, Arrays.asList(new SonarProperty("sonar.foo", "value")));
 
     assertThat(props.get("sonar.foo").toString()).isEqualTo("value");
@@ -127,8 +123,7 @@ public class AnalyzeProjectJobTest extends SonarTestCase {
 
   @Test
   public void userConfiguratorShouldOverrideConfiguratorHelperProps() throws Exception {
-    ((ServersManager) serversManager).getServerVersionCache().put("http://localhost:9000", "4.1");
-    AnalyzeProjectJob job = job(project);
+    final AnalyzeProjectJob job = job(project);
     Properties props = new Properties();
     job.configureAnalysis(MONITOR, props, Arrays.<SonarProperty>asList());
 
@@ -142,10 +137,10 @@ public class AnalyzeProjectJobTest extends SonarTestCase {
 
   @Test
   public void shouldCreateMarkersFromIssuesReport() throws Exception {
-    AnalyzeProjectJob job = job(project);
-    job.createMarkersFromReportOutput(MONITOR, new File("testdata/sonar-report.json"));
+    final AnalyzeProjectJob job = job(project);
+    job.createMarkersFromReportOutput(new File("testdata/sonar-report.json"));
 
-    List<IMarker> markers = Arrays.asList(project.findMarkers(SonarCorePlugin.MARKER_ID, true, IResource.DEPTH_INFINITE));
+    final List<IMarker> markers = Arrays.asList(project.findMarkers(SonarCorePlugin.MARKER_ID, true, IResource.DEPTH_INFINITE));
     assertThat(markers.size()).isEqualTo(6);
 
     Assert.assertThat(markers, JUnitMatchers.hasItem(new IsMarker("src/Findbugs.java", 5)));
@@ -156,13 +151,13 @@ public class AnalyzeProjectJobTest extends SonarTestCase {
   @Test
   public void shouldCleanAndCreateMarkersFromIncrementalAnalysis() throws Exception {
     AnalyzeProjectJob job = job(project);
-    job.createMarkersFromReportOutput(MONITOR, new File("testdata/sonar-report.json"));
+    job.createMarkersFromReportOutput(new File("testdata/sonar-report.json"));
 
     // During incremental analysis PMD file was not modified, Findbugs has one remaing issue and Checkstyle has no remaining issues
     job = job(project);
-    job.createMarkersFromReportOutput(MONITOR, new File("testdata/sonar-report-incremental.json"));
+    job.createMarkersFromReportOutput(new File("testdata/sonar-report-incremental.json"));
 
-    List<IMarker> markers = Arrays.asList(project.findMarkers(SonarCorePlugin.MARKER_ID, true, IResource.DEPTH_INFINITE));
+    final List<IMarker> markers = Arrays.asList(project.findMarkers(SonarCorePlugin.MARKER_ID, true, IResource.DEPTH_INFINITE));
     assertThat(markers.size()).isEqualTo(3);
 
     Assert.assertThat(markers, JUnitMatchers.hasItem(new IsMarker("src/Findbugs.java", 5)));
@@ -174,19 +169,21 @@ public class AnalyzeProjectJobTest extends SonarTestCase {
     private final String path;
     private final int line;
 
-    public IsMarker(String path, int line) {
+    public IsMarker(final String path, final int line) {
       this.path = path;
       this.line = line;
     }
 
-    public boolean matches(Object item) {
-      IMarker marker = (IMarker) item;
-      String actualPath = marker.getResource().getProjectRelativePath().toString();
-      int actualLine = marker.getAttribute(IMarker.LINE_NUMBER, -1);
-      return StringUtils.equals(actualPath, path) && (actualLine == line);
+    @Override
+    public boolean matches(final Object item) {
+      final IMarker marker = (IMarker) item;
+      final String actualPath = marker.getResource().getProjectRelativePath().toString();
+      final int actualLine = marker.getAttribute(IMarker.LINE_NUMBER, -1);
+      return StringUtils.equals(actualPath, path) && actualLine == line;
     }
 
-    public void describeTo(Description description) {
+    @Override
+    public void describeTo(final Description description) {
       // TODO Auto-generated method stub
     }
 

--- a/org.sonar.ide.eclipse.core.tests/src/test/java/org/sonar/ide/eclipse/core/internal/jobs/FakedVersionedSonarServer.java
+++ b/org.sonar.ide.eclipse.core.tests/src/test/java/org/sonar/ide/eclipse/core/internal/jobs/FakedVersionedSonarServer.java
@@ -1,0 +1,84 @@
+/*
+ * SonarQube Eclipse
+ * Copyright (C) 2010-2015 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.ide.eclipse.core.internal.jobs;
+
+import org.sonar.ide.eclipse.common.servers.ISonarServer;
+
+/**
+ * Dummy implementation of ISonarServer.
+ * 
+ * @author Hemantkumar Chigadani
+ */
+class FakedVersionedSonarServer implements ISonarServer {
+
+  private final ISonarServer server;
+  private final String version;
+
+  /**
+   * @param server
+   * @param version
+   *
+   */
+  public FakedVersionedSonarServer(final ISonarServer server, final String version) {
+    this.server = server;
+    this.version = version;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getUrl() {
+    return server.getUrl();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean hasCredentials() {
+    return server.hasCredentials();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getUsername() {
+    return server.getUsername();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getPassword() {
+    return server.getPassword();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getVersion() {
+    return this.version;
+  }
+
+}

--- a/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/jobs/AnalyzeProjectJob.java
+++ b/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/jobs/AnalyzeProjectJob.java
@@ -127,7 +127,7 @@ public class AnalyzeProjectJob extends Job {
     // Create markers
     long startMarker = System.currentTimeMillis();
     SonarCorePlugin.getDefault().debug("Create markers on project " + project.getName() + " resources...\n");
-    createMarkersFromReportOutput(monitor, outputFile);
+    createMarkersFromReportOutput(outputFile);
     SonarCorePlugin.getDefault().debug("Done in " + (System.currentTimeMillis() - startMarker) + "ms\n");
 
     // Update analysis date
@@ -152,7 +152,7 @@ public class AnalyzeProjectJob extends Job {
   }
 
   @VisibleForTesting
-  public void createMarkersFromReportOutput(final IProgressMonitor monitor, File outputFile) {
+  public void createMarkersFromReportOutput(File outputFile) {
     try (FileReader fileReader = new FileReader(outputFile)) {
       Object obj = JSONValue.parse(fileReader);
       JSONObject sonarResult = (JSONObject) obj;

--- a/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/servers/ISonarServerPreferenceConstansts.java
+++ b/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/servers/ISonarServerPreferenceConstansts.java
@@ -1,0 +1,33 @@
+/*
+ * SonarQube Eclipse
+ * Copyright (C) 2010-2015 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.ide.eclipse.core.internal.servers;
+
+/**
+ * @author Hemantkumar Chigadani
+ */
+@SuppressWarnings("nls")
+interface ISonarServerPreferenceConstansts {
+
+  static final String INITIALIZED = "initialized";
+
+  static final String AUTH = "auth";
+
+  static final String PREF_SERVERS = "servers";
+}

--- a/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/servers/SonarServer.java
+++ b/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/servers/SonarServer.java
@@ -20,7 +20,6 @@
 package org.sonar.ide.eclipse.core.internal.servers;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.equinox.security.storage.EncodingUtils;
@@ -30,13 +29,14 @@ import org.eclipse.equinox.security.storage.StorageException;
 import org.sonar.ide.eclipse.common.servers.ISonarServer;
 import org.sonar.ide.eclipse.core.internal.SonarCorePlugin;
 
-public final class SonarServer implements ISonarServer {
+@SuppressWarnings("nls")
+final class SonarServer implements ISonarServer {
 
   private final String url;
   private final boolean auth;
-  private String version;
+  private Version version;
 
-  public SonarServer(String url, String username, String password) {
+  SonarServer(final String url, final String username, final String password) {
     this(url, StringUtils.isNotBlank(password) && StringUtils.isNotBlank(username));
     if (auth) {
       setKeyForServerNode("username", username, false);
@@ -44,14 +44,24 @@ public final class SonarServer implements ISonarServer {
     }
   }
 
-  public SonarServer(String url) {
+  SonarServer(final String url) {
     this(url, false);
   }
 
-  public SonarServer(String url, boolean auth) {
+  SonarServer(final String url, final boolean auth) {
     Assert.isNotNull(url);
     this.url = url;
     this.auth = auth;
+  }
+
+  /**
+   * @param url
+   * @param auth
+   * @param version
+   */
+  public SonarServer(final String url, final boolean auth, final Version version) {
+    this(url, auth);
+    this.version = version;
   }
 
   @Override
@@ -77,27 +87,24 @@ public final class SonarServer implements ISonarServer {
   @CheckForNull
   @Override
   public String getVersion() {
-    return version;
+    return version.get(this);
   }
 
-  public void setVersion(@Nullable String version) {
-    this.version = version;
-  }
 
-  private String getKeyFromServerNode(String key) {
+  private String getKeyFromServerNode(final String key) {
     try {
-      return SecurePreferencesFactory.getDefault().node(ServersManager.PREF_SERVERS).node(EncodingUtils.encodeSlashes(getUrl())).get(key, "");
-    } catch (StorageException e) {
+      return SecurePreferencesFactory.getDefault().node(ISonarServerPreferenceConstansts.PREF_SERVERS).node(EncodingUtils.encodeSlashes(getUrl())).get(key, "");
+    } catch (final StorageException e) {
       return "";
     }
   }
 
-  private void setKeyForServerNode(String key, String value, boolean encrypt) {
+  private void setKeyForServerNode(final String key, final String value, final boolean encrypt) {
     try {
-      ISecurePreferences serverNode = SecurePreferencesFactory.getDefault().node(ServersManager.PREF_SERVERS)
+      final ISecurePreferences serverNode = SecurePreferencesFactory.getDefault().node(ISonarServerPreferenceConstansts.PREF_SERVERS)
         .node(EncodingUtils.encodeSlashes(getUrl()));
       serverNode.put(key, value, encrypt);
-    } catch (StorageException e) {
+    } catch (final StorageException e) {
       SonarCorePlugin.getDefault().error(e.getMessage(), e);
     }
   }
@@ -113,12 +120,12 @@ public final class SonarServer implements ISonarServer {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(final Object obj) {
     if (obj == this) {
       return true;
     }
     if (obj instanceof SonarServer) {
-      SonarServer sonarServer = (SonarServer) obj;
+      final SonarServer sonarServer = (SonarServer) obj;
       return getUrl().equals(sonarServer.getUrl());
     }
     return false;

--- a/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/servers/Version.java
+++ b/org.sonar.ide.eclipse.core/src/org/sonar/ide/eclipse/core/internal/servers/Version.java
@@ -1,0 +1,110 @@
+/*
+ * SonarQube Eclipse
+ * Copyright (C) 2010-2015 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.ide.eclipse.core.internal.servers;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.CheckForNull;
+import org.sonar.ide.eclipse.common.servers.ISonarServer;
+import org.sonar.ide.eclipse.core.internal.SonarCorePlugin;
+import org.sonar.ide.eclipse.wsclient.ISonarWSClientFacade;
+import org.sonar.ide.eclipse.wsclient.WSClientFactory;
+
+/**
+ * {@link ISonarServer} version details encapsulated separately here from {@link ServersManager}.<br>
+ * Lazy loading cacher for holding {@link ISonarServer} version.
+ *
+ * @see #get(ISonarServer)
+ *
+ * @author Hemantkumar Chigadani
+ */
+final class Version {
+
+  private static final Map<String, Version> serverVersionCache = new HashMap<String, Version>();
+
+  private final AtomicReference<String> v;
+
+  private Version() {
+
+    v = new AtomicReference<String>();
+  }
+
+  /**
+   * @param sonarServer
+   * @return the version
+   */
+  String get(final ISonarServer sonarServer) {
+    String serverVersion = v.get();
+    if (serverVersion == null) {
+      serverVersion = getServerVersion(sonarServer);
+      v.set(serverVersion);
+    }
+    return serverVersion;
+  }
+
+  /**
+   * Silence version fetcher.
+   *
+   * @param server
+   * @return
+   */
+  @SuppressWarnings("nls")
+  @CheckForNull
+  private String getServerVersion(final ISonarServer server) {
+    String serverVersion = null;
+    try {
+      final ISonarWSClientFacade sonarClient = WSClientFactory.getSonarClient(server);
+      serverVersion = sonarClient.getServerVersion();
+    } catch (final Exception e) {
+      SonarCorePlugin.getDefault().debug("Unable to get version of server " + server.getUrl() + ": " + e.getMessage() + "\n");
+    }
+    return serverVersion;
+  }
+
+  /**
+   * @param url {@link ISonarServer} url location.
+   * @return Cached version , if not found creates new version object.
+   */
+  static synchronized Version getVersion(final String url) {
+    Version version = serverVersionCache.get(url);
+    if (version == null) {
+      version = new Version();
+      serverVersionCache.put(url, version);
+    }
+    return version;
+  }
+
+  /**
+   * @param server
+   */
+  static synchronized void remove(final ISonarServer server) {
+    serverVersionCache.remove(server.getUrl());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String toString() {
+    return "Version [v=" + v + "]";
+  }
+
+}


### PR DESCRIPTION
Lazying caching of SonarQube server version improves performance if the client code is interested in servers details except version. Example User wants to edit the servers list in Eclipse preference when SonarQube server is not reachable.
Version caching and it's parsing has been encapsulated to a new Java file 'Version'.

Please note this improves the performance considerably when more than one SonarQube servers are  configured by user to analysis code. This helps a lot in auto-sonar-builder[Future concept] too.